### PR TITLE
Optimized fetching of instructions

### DIFF
--- a/include/chip8.h
+++ b/include/chip8.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <array>
-#include <unordered_map>
+#include <map>
 
 #include "graphics.h"
 
@@ -18,9 +18,7 @@ public:
     Chip8& operator=(const Chip8& other) = delete;
     constexpr Chip8& operator=(Chip8&& other) = delete; 
     void run();
-
-
-  
+    
 private:
     void load_game(const std::string& path);
     void handle_opcode();
@@ -29,7 +27,6 @@ private:
     void init_font();
     void init_opcode_table();
     void init_opcode_args();
-
     void inst_00E0();
     void inst_00EE();
     void inst_1NNN();
@@ -90,7 +87,6 @@ private:
         std::array<unsigned char, REG_AMOUNT> v;
     } _cpu;
     std::array<uint16_t, STACK_DEPTH> _stack;
-    
     uint16_t _opcode;
     struct 
     {
@@ -100,7 +96,6 @@ private:
         uint8_t x;
         uint8_t y;
     } _opcode_args;
-
     struct 
     {
         uint8_t _delay;
@@ -110,7 +105,6 @@ private:
     std::array<uint16_t, KEY_AMOUNT> _keypad;
     template<typename T>
     using Inst_fun = void (T::*)();
-    std::unordered_map<uint16_t, Inst_fun<Chip8>> _opcode_table;
+    std::map<uint16_t, Inst_fun<Chip8>> _opcode_table;
     Graphics _graphics;
-
 };

--- a/include/chip8.h
+++ b/include/chip8.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <array>
-#include <map>
+#include <unordered_map>
 
 #include "graphics.h"
 
@@ -110,7 +110,7 @@ private:
     std::array<uint16_t, KEY_AMOUNT> _keypad;
     template<typename T>
     using Inst_fun = void (T::*)();
-    std::map<uint16_t, Inst_fun<Chip8>> _opcode_table;
+    std::unordered_map<uint16_t, Inst_fun<Chip8>> _opcode_table;
     Graphics _graphics;
 
 };

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -123,11 +123,11 @@ void Chip8::handle_opcode()
 {
     _opcode = _memory[_cpu.pc] << 8 | _memory[_cpu.pc + 1];
     const uint16_t curr_pc = _cpu.pc;
-    bool exec_inst = false;
-    init_opcode_args();
-    init_opcode_table();
-    auto inst = _opcode_table.find_if(_opcode_table.begin(), _opcode_table.end(),
-                                     [auto entry]{(return _opcode | entry.first) == entry.first;});
+    auto inst = std::find_if(_opcode_table.begin(), _opcode_table.end(),
+                             [this](const auto& entry)
+                             {
+                                return (((entry.first & _opcode) == _opcode) && ((entry.first | _opcode) == entry.first));
+                             });
     if (inst == _opcode_table.end())
     {
         std::stringstream hex;
@@ -136,7 +136,8 @@ void Chip8::handle_opcode()
     }
     else
     {
-        *(this->*inst.second)();
+        init_opcode_args();
+        (this->*((*inst).second))();
         std::cout << "Executed Opcode " << "0x" << std::hex << _opcode << " at address 0x" << std::hex << curr_pc << std::endl;
     }
 }
@@ -213,40 +214,40 @@ void Chip8::init_font()
 
 void Chip8::init_opcode_table()
 {
-  _opcode_table[0x00E0 & _opcode] = &Chip8::inst_00E0;
-  _opcode_table[0x00EE0 & _opcode] = &Chip8::inst_00EE;
-  _opcode_table[0x1FFF0 & _opcode] = &Chip8::inst_1NNN;
-  _opcode_table[0x2FFF0 & _opcode] = &Chip8::inst_2NNN;
-  _opcode_table[0x3FFF0 & _opcode] = &Chip8::inst_3XNN;
-  _opcode_table[0x4FFF0 & _opcode] = &Chip8::inst_4XNN;
-  _opcode_table[0x5FF00 & _opcode] = &Chip8::inst_5XY0;
-  _opcode_table[0x6FFF0 & _opcode] = &Chip8::inst_6XNN;
-  _opcode_table[0x7FFF0 & _opcode] = &Chip8::inst_7XNN;
-  _opcode_table[0x8FF00 & _opcode] = &Chip8::inst_8XY0;
-  _opcode_table[0x8FF10 & _opcode] = &Chip8::inst_8XY1;
-  _opcode_table[0x8FF20 & _opcode] = &Chip8::inst_8XY2;
-  _opcode_table[0x8FF30 & _opcode] = &Chip8::inst_8XY3;
-  _opcode_table[0x8FF40 & _opcode] = &Chip8::inst_8XY4;
-  _opcode_table[0x8FF50 & _opcode] = &Chip8::inst_8XY5;
-  _opcode_table[0x8FF60 & _opcode] = &Chip8::inst_8XY6;
-  _opcode_table[0x8FF70 & _opcode] = &Chip8::inst_8XY7;
-  _opcode_table[0x8FFE0 & _opcode] = &Chip8::inst_8XYE;
-  _opcode_table[0x9FF00 & _opcode] = &Chip8::inst_9XY0; 
-  _opcode_table[0xAFFF0 & _opcode] = &Chip8::inst_ANNN;
-  _opcode_table[0xBFFF0 & _opcode] = &Chip8::inst_BNNN;
-  _opcode_table[0xCFFF0 & _opcode] = &Chip8::inst_CXNN;
-  _opcode_table[0xDFFF0 & _opcode] = &Chip8::inst_DXYN;
-  _opcode_table[0xEF9E0 & _opcode] = &Chip8::inst_EX9E;
-  _opcode_table[0xEFA10 & _opcode] = &Chip8::inst_EXA1;
-  _opcode_table[0xFF070 & _opcode] = &Chip8::inst_FX07;
-  _opcode_table[0xFF0A0 & _opcode] = &Chip8::inst_FX0A;
-  _opcode_table[0xFF150 & _opcode] = &Chip8::inst_FX15;
-  _opcode_table[0xFF180 & _opcode] = &Chip8::inst_FX18;
-  _opcode_table[0xFF1E0 & _opcode] = &Chip8::inst_FX1E;
-  _opcode_table[0xFF290 & _opcode] = &Chip8::inst_FX29;
-  _opcode_table[0xFF330 & _opcode] = &Chip8::inst_FX33;
-  _opcode_table[0xFF550 & _opcode] = &Chip8::inst_FX55;
-  _opcode_table[0xFF650 & _opcode] = &Chip8::inst_FX65;
+  _opcode_table[0x00E0] = &Chip8::inst_00E0;
+  _opcode_table[0x00EE] = &Chip8::inst_00EE;
+  _opcode_table[0x1FFF] = &Chip8::inst_1NNN;
+  _opcode_table[0x2FFF] = &Chip8::inst_2NNN;
+  _opcode_table[0x3FFF] = &Chip8::inst_3XNN;
+  _opcode_table[0x4FFF] = &Chip8::inst_4XNN;
+  _opcode_table[0x5FF0] = &Chip8::inst_5XY0;
+  _opcode_table[0x6FFF] = &Chip8::inst_6XNN;
+  _opcode_table[0x7FFF] = &Chip8::inst_7XNN;
+  _opcode_table[0x8FF0] = &Chip8::inst_8XY0;
+  _opcode_table[0x8FF1] = &Chip8::inst_8XY1;
+  _opcode_table[0x8FF2] = &Chip8::inst_8XY2;
+  _opcode_table[0x8FF3] = &Chip8::inst_8XY3;
+  _opcode_table[0x8FF4] = &Chip8::inst_8XY4;
+  _opcode_table[0x8FF5] = &Chip8::inst_8XY5;
+  _opcode_table[0x8FF6] = &Chip8::inst_8XY6;
+  _opcode_table[0x8FF7] = &Chip8::inst_8XY7;
+  _opcode_table[0x8FFE] = &Chip8::inst_8XYE;
+  _opcode_table[0x9FF0] = &Chip8::inst_9XY0; 
+  _opcode_table[0xAFFF] = &Chip8::inst_ANNN;
+  _opcode_table[0xBFFF] = &Chip8::inst_BNNN;
+  _opcode_table[0xCFFF] = &Chip8::inst_CXNN;
+  _opcode_table[0xDFFF] = &Chip8::inst_DXYN;
+  _opcode_table[0xEF9E] = &Chip8::inst_EX9E;
+  _opcode_table[0xEFA1] = &Chip8::inst_EXA1;
+  _opcode_table[0xFF07] = &Chip8::inst_FX07;
+  _opcode_table[0xFF0A] = &Chip8::inst_FX0A;
+  _opcode_table[0xFF15] = &Chip8::inst_FX15;
+  _opcode_table[0xFF18] = &Chip8::inst_FX18;
+  _opcode_table[0xFF1E] = &Chip8::inst_FX1E;
+  _opcode_table[0xFF29] = &Chip8::inst_FX29;
+  _opcode_table[0xFF33] = &Chip8::inst_FX33;
+  _opcode_table[0xFF55] = &Chip8::inst_FX55;
+  _opcode_table[0xFF65] = &Chip8::inst_FX65;
 }
 
 /**

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -25,7 +25,6 @@ Chip8::Chip8(const std::string& path) :  _opcode(0), _graphics(RES_WIDTH, RES_HE
     std::memset(&_timer, 0, sizeof(_timer));    
     init_font();
     load_game(path);
-    init_opcode_table();
     std::srand(std::time(nullptr));
 }
 
@@ -125,17 +124,11 @@ void Chip8::handle_opcode()
     _opcode = _memory[_cpu.pc] << 8 | _memory[_cpu.pc + 1];
     const uint16_t curr_pc = _cpu.pc;
     bool exec_inst = false;
-    for (auto const& entry : _opcode_table)
-    {
-        if (((entry.first & _opcode) == _opcode) && ((entry.first | _opcode) == entry.first))
-        {
-            init_opcode_args();
-            (*this.*entry.second)();
-            exec_inst = true;
-            break;
-        }
-    } 
-    if (!exec_inst)
+    init_opcode_args();
+    init_opcode_table();
+    auto inst = _opcode_table.find_if(_opcode_table.begin(), _opcode_table.end(),
+                                     [auto entry]{(return _opcode | entry.first) == entry.first;});
+    if (inst == _opcode_table.end())
     {
         std::stringstream hex;
         hex << "0x" << std::hex << _opcode << " at address 0x" << std::hex << curr_pc << std::endl;
@@ -143,6 +136,7 @@ void Chip8::handle_opcode()
     }
     else
     {
+        *(this->*inst.second)();
         std::cout << "Executed Opcode " << "0x" << std::hex << _opcode << " at address 0x" << std::hex << curr_pc << std::endl;
     }
 }
@@ -219,40 +213,40 @@ void Chip8::init_font()
 
 void Chip8::init_opcode_table()
 {
-  _opcode_table[0x00E0] = &Chip8::inst_00E0;
-  _opcode_table[0x00EE] = &Chip8::inst_00EE;
-  _opcode_table[0x1FFF] = &Chip8::inst_1NNN;
-  _opcode_table[0x2FFF] = &Chip8::inst_2NNN;
-  _opcode_table[0x3FFF] = &Chip8::inst_3XNN;
-  _opcode_table[0x4FFF] = &Chip8::inst_4XNN;
-  _opcode_table[0x5FF0] = &Chip8::inst_5XY0;
-  _opcode_table[0x6FFF] = &Chip8::inst_6XNN;
-  _opcode_table[0x7FFF] = &Chip8::inst_7XNN;
-  _opcode_table[0x8FF0] = &Chip8::inst_8XY0;
-  _opcode_table[0x8FF1] = &Chip8::inst_8XY1;
-  _opcode_table[0x8FF2] = &Chip8::inst_8XY2;
-  _opcode_table[0x8FF3] = &Chip8::inst_8XY3;
-  _opcode_table[0x8FF4] = &Chip8::inst_8XY4;
-  _opcode_table[0x8FF5] = &Chip8::inst_8XY5;
-  _opcode_table[0x8FF6] = &Chip8::inst_8XY6;
-  _opcode_table[0x8FF7] = &Chip8::inst_8XY7;
-  _opcode_table[0x8FFE] = &Chip8::inst_8XYE;
-  _opcode_table[0x9FF0] = &Chip8::inst_9XY0; 
-  _opcode_table[0xAFFF] = &Chip8::inst_ANNN;
-  _opcode_table[0xBFFF] = &Chip8::inst_BNNN;
-  _opcode_table[0xCFFF] = &Chip8::inst_CXNN;
-  _opcode_table[0xDFFF] = &Chip8::inst_DXYN;
-  _opcode_table[0xEF9E] = &Chip8::inst_EX9E;
-  _opcode_table[0xEFA1] = &Chip8::inst_EXA1;
-  _opcode_table[0xFF07] = &Chip8::inst_FX07;
-  _opcode_table[0xFF0A] = &Chip8::inst_FX0A;
-  _opcode_table[0xFF15] = &Chip8::inst_FX15;
-  _opcode_table[0xFF18] = &Chip8::inst_FX18;
-  _opcode_table[0xFF1E] = &Chip8::inst_FX1E;
-  _opcode_table[0xFF29] = &Chip8::inst_FX29;
-  _opcode_table[0xFF33] = &Chip8::inst_FX33;
-  _opcode_table[0xFF55] = &Chip8::inst_FX55;
-  _opcode_table[0xFF65] = &Chip8::inst_FX65;
+  _opcode_table[0x00E0 & _opcode] = &Chip8::inst_00E0;
+  _opcode_table[0x00EE0 & _opcode] = &Chip8::inst_00EE;
+  _opcode_table[0x1FFF0 & _opcode] = &Chip8::inst_1NNN;
+  _opcode_table[0x2FFF0 & _opcode] = &Chip8::inst_2NNN;
+  _opcode_table[0x3FFF0 & _opcode] = &Chip8::inst_3XNN;
+  _opcode_table[0x4FFF0 & _opcode] = &Chip8::inst_4XNN;
+  _opcode_table[0x5FF00 & _opcode] = &Chip8::inst_5XY0;
+  _opcode_table[0x6FFF0 & _opcode] = &Chip8::inst_6XNN;
+  _opcode_table[0x7FFF0 & _opcode] = &Chip8::inst_7XNN;
+  _opcode_table[0x8FF00 & _opcode] = &Chip8::inst_8XY0;
+  _opcode_table[0x8FF10 & _opcode] = &Chip8::inst_8XY1;
+  _opcode_table[0x8FF20 & _opcode] = &Chip8::inst_8XY2;
+  _opcode_table[0x8FF30 & _opcode] = &Chip8::inst_8XY3;
+  _opcode_table[0x8FF40 & _opcode] = &Chip8::inst_8XY4;
+  _opcode_table[0x8FF50 & _opcode] = &Chip8::inst_8XY5;
+  _opcode_table[0x8FF60 & _opcode] = &Chip8::inst_8XY6;
+  _opcode_table[0x8FF70 & _opcode] = &Chip8::inst_8XY7;
+  _opcode_table[0x8FFE0 & _opcode] = &Chip8::inst_8XYE;
+  _opcode_table[0x9FF00 & _opcode] = &Chip8::inst_9XY0; 
+  _opcode_table[0xAFFF0 & _opcode] = &Chip8::inst_ANNN;
+  _opcode_table[0xBFFF0 & _opcode] = &Chip8::inst_BNNN;
+  _opcode_table[0xCFFF0 & _opcode] = &Chip8::inst_CXNN;
+  _opcode_table[0xDFFF0 & _opcode] = &Chip8::inst_DXYN;
+  _opcode_table[0xEF9E0 & _opcode] = &Chip8::inst_EX9E;
+  _opcode_table[0xEFA10 & _opcode] = &Chip8::inst_EXA1;
+  _opcode_table[0xFF070 & _opcode] = &Chip8::inst_FX07;
+  _opcode_table[0xFF0A0 & _opcode] = &Chip8::inst_FX0A;
+  _opcode_table[0xFF150 & _opcode] = &Chip8::inst_FX15;
+  _opcode_table[0xFF180 & _opcode] = &Chip8::inst_FX18;
+  _opcode_table[0xFF1E0 & _opcode] = &Chip8::inst_FX1E;
+  _opcode_table[0xFF290 & _opcode] = &Chip8::inst_FX29;
+  _opcode_table[0xFF330 & _opcode] = &Chip8::inst_FX33;
+  _opcode_table[0xFF550 & _opcode] = &Chip8::inst_FX55;
+  _opcode_table[0xFF650 & _opcode] = &Chip8::inst_FX65;
 }
 
 /**


### PR DESCRIPTION
Optimized the fetching of the opcode and its instruction to utilize maps advantages by using find_if.
The search for the opcode in the opcode table is now O(log 35) instead of O(35).